### PR TITLE
feat: add vercel deployment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,30 @@ You can host this project yourself — just give proper credit by linking to thi
 ---
 
 <p align="center">
-  Made with ❤️ by <a href="https://github.com/Sandipeyy">Sandipeyy</a>  
-  •  
+  Made with ❤️ by <a href="https://github.com/Sandipeyy">Sandipeyy</a>
+  •
   <a href="mailto:contact.nepoflix@gmail.com">contact.nepoflix@gmail.com</a>
 </p>
+
+---
+
+## 🚀 Deploying on Vercel
+
+This repository includes configuration for hosting on [Vercel](https://vercel.com).
+
+1. Install dependencies and build the frontend:
+   ```bash
+   npm install
+   npm run build
+   ```
+2. Deploy using the Vercel CLI:
+   ```bash
+   npm i -g vercel
+   vercel
+   vercel --prod
+   ```
+
+The static site is served from the `dist/` directory and proxy logic is handled
+via serverless functions in the `api/` folder.
 
 </div>

--- a/api/m3u8proxy.ts
+++ b/api/m3u8proxy.ts
@@ -1,0 +1,51 @@
+import http from 'node:http';
+import https from 'node:https';
+
+export default function handler(req: any, res: any) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 200;
+    res.end();
+    return;
+  }
+
+  const path = req.query?.path;
+  if (!path) {
+    res.statusCode = 400;
+    res.end('Missing target URL');
+    return;
+  }
+
+  const target = Array.isArray(path) ? path.join('/') : path;
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch (err: any) {
+    res.statusCode = 400;
+    res.end('Invalid URL');
+    return;
+  }
+
+  const client = url.protocol === 'http:' ? http : https;
+  const proxyReq = client.request(url, proxyRes => {
+    Object.entries(proxyRes.headers).forEach(([key, value]) => {
+      if (value !== undefined) {
+        res.setHeader(key, value as any);
+      }
+    });
+    res.statusCode = proxyRes.statusCode || 500;
+    proxyRes.pipe(res);
+  });
+
+  proxyReq.on('error', (err: any) => {
+    res.statusCode = 500;
+    res.end(err.message);
+  });
+
+  if (req.method === 'GET') {
+    proxyReq.end();
+  } else {
+    req.pipe(proxyReq);
+  }
+}

--- a/api/proxy.py
+++ b/api/proxy.py
@@ -1,0 +1,39 @@
+import json
+import requests
+import cloudscraper
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
+from http import HTTPStatus
+
+session = requests.Session()
+retry = Retry(total=3,
+              status_forcelist=[429, 500, 502, 503, 504],
+              allowed_methods=["GET", "HEAD", "OPTIONS", "POST"],
+              backoff_factor=1)
+adapter = HTTPAdapter(max_retries=retry)
+session.mount("http://", adapter)
+session.mount("https://", adapter)
+
+def handler(request):
+    try:
+        data = request.json()
+        url = data.get("url")
+        method = data.get("method", "GET").upper()
+        headers = data.get("headers", {})
+        use_cf = data.get("cf", False)
+        timeout = data.get("timeout", 30)
+
+        if not url or method not in {"GET", "POST"}:
+            body = json.dumps({"error": "Invalid request"})
+            return body, HTTPStatus.BAD_REQUEST, {"content-type": "application/json"}
+
+        sess = cloudscraper.create_scraper() if use_cf else session
+        if method == "GET":
+            resp = sess.get(url, headers=headers, timeout=timeout)
+        else:
+            resp = sess.post(url, headers=headers,
+                             data=data.get("form_data", {}), timeout=timeout)
+        return resp.content, resp.status_code, dict(resp.headers)
+    except Exception as exc:
+        body = json.dumps({"error": str(exc)})
+        return body, HTTPStatus.INTERNAL_SERVER_ERROR, {"content-type": "application/json"}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "tw-animate-css": "^1.3.4",
+    "typescript": "^5.9.2",
     "vite": "^6.3.5"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+cloudscraper

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": null,
+  "rewrites": [
+    { "source": "/api/m3u8proxy/:path*", "destination": "/api/m3u8proxy.ts" },
+    { "source": "/api/proxy", "destination": "/api/proxy.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure vercel build and API rewrites
- add serverless m3u8 and HTTP proxy functions
- document vercel deployment steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `python -m py_compile api/proxy.py`


------
https://chatgpt.com/codex/tasks/task_e_689a62cd39d083269c0182892a67fba1