### PR TITLE
fix cors for hosted endpoints

### DIFF
--- a/backend/m3u8proxy/src/libraries/server.ts
+++ b/backend/m3u8proxy/src/libraries/server.ts
@@ -734,6 +734,9 @@ export async function proxyM3U8(url: string, headers: any, res: http.ServerRespo
         url: url,
         headers: headers
     });
+
+    // Ensure clients from any origin can access the proxied playlist
+    res.setHeader("Access-Control-Allow-Origin", "*");
     
     const req = await axios(url, {
         headers: headers,

--- a/skip-marker-backend/index.js
+++ b/skip-marker-backend/index.js
@@ -14,7 +14,15 @@ const parseAllowedOrigins = (v) =>
     .filter(Boolean);
 
 // Example: ALLOWED_ORIGINS=https://nepo-flix-v2-y5as.vercel.app,http://localhost:5173
-const ALLOWED = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
+// Always allow our public deployments in addition to any provided env list.
+const ENV_ALLOWED = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
+const DEFAULT_ALLOWED = [
+  'https://nepoflix.micorp.pro',
+  'https://nepoflix.vercel.app'
+];
+const ALLOWED = ENV_ALLOWED.length
+  ? Array.from(new Set([...ENV_ALLOWED, ...DEFAULT_ALLOWED]))
+  : [];
 
 // If no allowlist is configured, default to "*" (useful for local dev)
 const corsOptionsDelegate = (req, cb) => {


### PR DESCRIPTION
## Summary
- include nepoflix domains in skip-marker service CORS allowlist
- set Access-Control-Allow-Origin on m3u8 proxy responses

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 72 errors)
- `npm --prefix skip-marker-backend test` (fails: Error: no test specified)
- `npm --prefix backend/m3u8proxy test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689d5ff0dbe48326874540a37c002dba